### PR TITLE
Update QA Console to support toggling winners

### DIFF
--- a/Examples/QAConsoleIntegration/QAConsoleIntegration.xcodeproj/project.pbxproj
+++ b/Examples/QAConsoleIntegration/QAConsoleIntegration.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		015EEAE5271F5F7E000F0D05 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 015EEAE3271F5F7E000F0D05 /* Main.storyboard */; };
 		015EEAE7271F5F89000F0D05 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 015EEAE6271F5F89000F0D05 /* Assets.xcassets */; };
 		015EEAEA271F5F89000F0D05 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 015EEAE8271F5F89000F0D05 /* LaunchScreen.storyboard */; };
-		015EEAF3271F60B8000F0D05 /* Apptimize in Frameworks */ = {isa = PBXBuildFile; productRef = 015EEAF2271F60B8000F0D05 /* Apptimize */; };
 		015EEAF8271F68D9000F0D05 /* ApptimizeQAConsole in Frameworks */ = {isa = PBXBuildFile; productRef = 015EEAF7271F68D9000F0D05 /* ApptimizeQAConsole */; };
+		01D4DB91273ADD3E00DC100D /* Apptimize in Frameworks */ = {isa = PBXBuildFile; productRef = 01D4DB90273ADD3E00DC100D /* Apptimize */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +27,7 @@
 		015EEAE9271F5F89000F0D05 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		015EEAEB271F5F89000F0D05 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		015EEAF5271F60CA000F0D05 /* apptimize-qa-console-ios */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "apptimize-qa-console-ios"; path = ../..; sourceTree = "<group>"; };
+		01D4DB8A273AD8EB00DC100D /* Apptimize.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Apptimize.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -34,8 +35,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				01D4DB91273ADD3E00DC100D /* Apptimize in Frameworks */,
 				015EEAF8271F68D9000F0D05 /* ApptimizeQAConsole in Frameworks */,
-				015EEAF3271F60B8000F0D05 /* Apptimize in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -85,6 +86,7 @@
 		015EEAF6271F68D9000F0D05 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				01D4DB8A273AD8EB00DC100D /* Apptimize.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -106,8 +108,8 @@
 			);
 			name = QAConsoleIntegration;
 			packageProductDependencies = (
-				015EEAF2271F60B8000F0D05 /* Apptimize */,
 				015EEAF7271F68D9000F0D05 /* ApptimizeQAConsole */,
+				01D4DB90273ADD3E00DC100D /* Apptimize */,
 			);
 			productName = QAConsoleIntegration;
 			productReference = 015EEADA271F5F7E000F0D05 /* QAConsoleIntegration.app */;
@@ -138,7 +140,7 @@
 			);
 			mainGroup = 015EEAD1271F5F7E000F0D05;
 			packageReferences = (
-				015EEAF1271F60B8000F0D05 /* XCRemoteSwiftPackageReference "apptimize-ios-kit" */,
+				01D4DB8F273ADD3E00DC100D /* XCRemoteSwiftPackageReference "apptimize-ios-kit" */,
 			);
 			productRefGroup = 015EEADB271F5F7E000F0D05 /* Products */;
 			projectDirPath = "";
@@ -391,25 +393,25 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		015EEAF1271F60B8000F0D05 /* XCRemoteSwiftPackageReference "apptimize-ios-kit" */ = {
+		01D4DB8F273ADD3E00DC100D /* XCRemoteSwiftPackageReference "apptimize-ios-kit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/urbanairship/apptimize-ios-kit";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		015EEAF2271F60B8000F0D05 /* Apptimize */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 015EEAF1271F60B8000F0D05 /* XCRemoteSwiftPackageReference "apptimize-ios-kit" */;
-			productName = Apptimize;
-		};
 		015EEAF7271F68D9000F0D05 /* ApptimizeQAConsole */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ApptimizeQAConsole;
+		};
+		01D4DB90273ADD3E00DC100D /* Apptimize */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 01D4DB8F273ADD3E00DC100D /* XCRemoteSwiftPackageReference "apptimize-ios-kit" */;
+			productName = Apptimize;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/QAConsoleIntegration/QAConsoleIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/QAConsoleIntegration/QAConsoleIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Apptimize",
         "repositoryURL": "https://github.com/urbanairship/apptimize-ios-kit",
         "state": {
-          "branch": "master",
-          "revision": "1c4972d57c8a5d56a6f15dfa80111d2321e6d5f1",
-          "version": null
+          "branch": null,
+          "revision": "87532874e634c3d0ada8b7aca77fb3b851d41cce",
+          "version": "3.5.7"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,9 +5,9 @@
         "package": "Apptimize",
         "repositoryURL": "https://github.com/urbanairship/apptimize-ios-kit",
         "state": {
-          "branch": "master",
-          "revision": "1c4972d57c8a5d56a6f15dfa80111d2321e6d5f1",
-          "version": null
+          "branch": null,
+          "revision": "7feae05db04f50afbd9ec66c8d82f43ddd826e45",
+          "version": "3.5.8"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["ApptimizeQAConsole"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/urbanairship/apptimize-ios-kit", from: "3.4.19")
+        .package(url: "https://github.com/urbanairship/apptimize-ios-kit", from: "3.5.8")
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Apptimize QA Console for iOS
 
-![https://github.com/urbanairship/apptimize-qa-console-ios/releases/latest](https://img.shields.io/github/v/release/urbanairship/apptimize-qa-console-ios)![](https://img.shields.io/badge/Swift-5.0-F05138)![#cocoapods](https://img.shields.io/badge/package-cocoapods-success)![#swift-package](https://img.shields.io/badge/package-Swift%20Package-success)![#license](https://img.shields.io/badge/license-Apache%202.0-orange)
+![https://github.com/urbanairship/apptimize-qa-console-ios/releases/latest](https://img.shields.io/github/v/release/urbanairship/apptimize-qa-console-ios) ![](https://img.shields.io/badge/Swift-5.0-F05138) ![#cocoapods](https://img.shields.io/badge/package-cocoapods-success) ![#swift-package](https://img.shields.io/badge/package-Swift%20Package-success) ![#license](https://img.shields.io/badge/license-Apache%202.0-orange)
 
 For more information see the [QA Console FAQ page](https://faq.apptimize.com/hc/en-us/articles/360021675293-How-do-I-use-the-Apptimize-QA-Console-).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Apptimize QA Console for iOS
 
+![https://github.com/urbanairship/apptimize-qa-console-ios/releases/latest](https://img.shields.io/github/v/release/urbanairship/apptimize-qa-console-ios)![](https://img.shields.io/badge/Swift-5.0-F05138)![#cocoapods](https://img.shields.io/badge/package-cocoapods-success)![#swift-package](https://img.shields.io/badge/package-Swift%20Package-success)![#license](https://img.shields.io/badge/license-Apache%202.0-orange)
+
 For more information see the [QA Console FAQ page](https://faq.apptimize.com/hc/en-us/articles/360021675293-How-do-I-use-the-Apptimize-QA-Console-).
 
 ## Introduction
@@ -74,4 +76,9 @@ Refer to CocoaPod’s [Getting Started Guide](https://guides.cocoapods.org/using
    ```swift
    ApptimizeQAConsole.display()
    ```
+
+## Notes
+
+* In order to display *Instant Updates* while using the QA console to force specific variants, you will need to add the `ApptimizeForceVariantsShowWinnersAndInstantUpdates` **Boolean** value to your `Info.plist` with the value set to `YES` (or if you call `Apptimize.start(withApplicationKey:options:)` you should add the `ApptimizeForceVariantsShowWinnersAndInstantUpdatesOption` with a value of `YES` to the `options` dictionary).
+* You can automatically refresh your UI whenever the QA Console is hidden if you wish by listening to the notifications `NSNotification.Name.ApptimizeQAConsoleWillDisappear` and `NSNotification.Name.ApptimizeQAConsoleWillAppear`.
 

--- a/Sources/ApptimizeQAConsole/ApptimizeQAConsole.swift
+++ b/Sources/ApptimizeQAConsole/ApptimizeQAConsole.swift
@@ -8,8 +8,13 @@
 import UIKit
 import Apptimize
 
+public extension NSNotification.Name {
+    static let ApptimizeQAConsoleWillAppear = Notification.Name("ApptimizeQAConsoleWillAppear")
+    static let ApptimizeQAConsoleWillDisappear = Notification.Name("ApptimizeQAConsoleWillDisappear")
+}
+
 public class ApptimizeQAConsole {
-    fileprivate static let shared = ApptimizeQAConsole()
+    internal static let shared = ApptimizeQAConsole()
     
     private var _isViewControllerPresented = false
     private var rootViewController: UIViewController?
@@ -33,6 +38,8 @@ public class ApptimizeQAConsole {
         }
         shared.rootViewController = root
 
+        NotificationCenter.default.post(name: NSNotification.Name.ApptimizeQAConsoleWillAppear, object: shared)
+
         let navigation = UINavigationController(rootViewController: root)
         controller.present(navigation, animated: true, completion: nil)
         shared._isViewControllerPresented = true
@@ -43,7 +50,13 @@ public class ApptimizeQAConsole {
             return
         }
         
+        NotificationCenter.default.post(name: NSNotification.Name.ApptimizeQAConsoleWillDisappear, object: shared)
+
         controller.dismiss(animated: true)
+    }
+    
+    public static func version() -> String {
+        return ApptimizeQAConsoleVersion.Version
     }
 }
 

--- a/Sources/ApptimizeQAConsole/ConsoleTableViewCell.swift
+++ b/Sources/ApptimizeQAConsole/ConsoleTableViewCell.swift
@@ -11,7 +11,6 @@ class ConsoleTableViewCell: UITableViewCell {
     
     private (set) var item: VariantInfo?
     
-    
     func setVariant(variant: VariantInfo, isSelected: Bool) {
         self.item = variant
         self.reloadUi()

--- a/Sources/ApptimizeQAConsole/Version.swift
+++ b/Sources/ApptimizeQAConsole/Version.swift
@@ -1,0 +1,9 @@
+//
+//  Version.swift
+//
+
+import Foundation
+
+class ApptimizeQAConsoleVersion {
+    public static var Version = "1.0.2"
+}


### PR DESCRIPTION
- This change requires a newer version of apptimize (3.5.8 or newer) and the package now reflects the requirement.
- Version number is now included in the console view.
- New notifications whenever the qa console is shown and hidden (NSNotification.Name.ApptimizeQAConsoleWillAppear & NSNotification.Name.ApptimizeQAConsoleWillDisappear) can be used to update ui.
- Updates the test application to take advantage of new notifications.